### PR TITLE
Add std feature, disabled by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ A Rust implementation of the 1-Wire protocol for embedded-hal
 
 [dependencies]
 embedded-hal = {version="0.2.3", features=["unproven"]}
+
+[features]
+std = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,3 +17,13 @@ pub enum OneWireError<E> {
     CrcMismatch,
     Timeout,
 }
+
+#[cfg(feature = "std")]
+impl<E: Debug> std::error::Error for OneWireError<E> {}
+
+#[cfg(feature = "std")]
+impl<E: Debug> core::fmt::Display for OneWireError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use embedded_hal::blocking::delay::DelayUs;
 use embedded_hal::digital::v2::{InputPin, OutputPin};


### PR DESCRIPTION
It's useful to have `std::error::Error` implementations for STD usecases as it allows interop with the `anyhow!` crate.